### PR TITLE
chore(ci): remove pnpm version to use packageManager field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fix the release workflow failure caused by pnpm/action-setup@v4 detecting conflicting version specifications.

## Problem

The workflow specified `version: 10` in the action config, but the repo also has `packageManager: pnpm@10.12.4` in package.json. The action now enforces a single source of truth and fails with:

```
Error: Multiple versions of pnpm specified
```

## Solution

Remove the explicit `version` parameter from pnpm/action-setup, allowing it to automatically read from the `packageManager` field in package.json.