### PR TITLE
chore(ci): use GitHub App token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,19 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -54,9 +62,9 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GIT_AUTHOR_NAME: TxnLab Release Bot[bot]
+          GIT_AUTHOR_EMAIL: txnlab-release-bot[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: TxnLab Release Bot[bot]
+          GIT_COMMITTER_EMAIL: txnlab-release-bot[bot]@users.noreply.github.com
         run: npx semantic-release


### PR DESCRIPTION
## Summary

Update the release workflow to use a GitHub App token instead of the default `GITHUB_TOKEN`. This allows semantic-release to push version bumps and changelog updates directly to the protected `main` branch.

## Problem

The default `GITHUB_TOKEN` cannot bypass branch protection rules, causing the release workflow to fail when `@semantic-release/git` tries to push commits back to main.

## Solution

Use the `actions/create-github-app-token` action to generate a token from the TxnLab Release Bot GitHub App, which can be added to the ruleset bypass list.

## Changes

- Add token generation step using `actions/create-github-app-token@v2`
- Pass generated token to checkout action
- Use generated token for `GITHUB_TOKEN` in release step
- Update git author/committer to use the bot identity