### PR TITLE
chore(e2e): derive playwright docker image version from package

### DIFF
--- a/e2e/scripts/run-e2e-docker.sh
+++ b/e2e/scripts/run-e2e-docker.sh
@@ -26,8 +26,9 @@ if ! docker info > /dev/null 2>&1; then
   exit 1
 fi
 
-# Use the official Playwright Docker image matching our version
-PLAYWRIGHT_VERSION="v1.57.0"
+# Use the official Playwright Docker image matching the installed @playwright/test version
+# Derived from the package so the image tag cannot drift from the npm pin
+PLAYWRIGHT_VERSION="v$(cd "$E2E_DIR" && node -p "require('@playwright/test/package.json').version")"
 IMAGE="mcr.microsoft.com/playwright:${PLAYWRIGHT_VERSION}"
 
 echo "Using Playwright image: $IMAGE"

--- a/e2e/scripts/update-snapshots.sh
+++ b/e2e/scripts/update-snapshots.sh
@@ -14,6 +14,13 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+# Default to chromium project (matches CI); callers can override via args,
+# e.g. `pnpm test:e2e:update:docker -- --project=vue-chromium`
+PROJECT_ARGS=("$@")
+if [ ${#PROJECT_ARGS[@]} -eq 0 ]; then
+  PROJECT_ARGS=(--project=chromium)
+fi
+
 echo -e "${YELLOW}Updating visual regression snapshots using Docker...${NC}"
 echo ""
 
@@ -23,12 +30,14 @@ if ! docker info > /dev/null 2>&1; then
   exit 1
 fi
 
-# Use the official Playwright Docker image matching our version
-PLAYWRIGHT_VERSION="v1.57.0"
+# Use the official Playwright Docker image matching the installed @playwright/test version
+# Derived from the package so the image tag cannot drift from the npm pin
+PLAYWRIGHT_VERSION="v$(cd "$E2E_DIR" && node -p "require('@playwright/test/package.json').version")"
 IMAGE="mcr.microsoft.com/playwright:${PLAYWRIGHT_VERSION}"
 
 echo "Using Playwright image: $IMAGE"
 echo "Mounting: $ROOT_DIR -> /work"
+echo "Project args: ${PROJECT_ARGS[*]}"
 echo ""
 
 # Run the update command in Docker
@@ -40,9 +49,11 @@ docker run --rm \
   -v "$ROOT_DIR:/work" \
   -v /work/node_modules \
   -v /work/packages/react/node_modules \
+  -v /work/packages/vue/node_modules \
   -v /work/examples/react/node_modules \
   -v /work/examples/react-css-only/node_modules \
   -v /work/examples/react-custom/node_modules \
+  -v /work/examples/vue/node_modules \
   -v /work/e2e/node_modules \
   -w /work \
   -e CI=true \
@@ -53,7 +64,7 @@ docker run --rm \
     pnpm install --frozen-lockfile && \
     pnpm build && \
     cd e2e && \
-    pnpm e2e:update --project=chromium
+    pnpm e2e:update ${PROJECT_ARGS[*]}
   "
 
 echo ""


### PR DESCRIPTION
## Summary

The Docker helper scripts hardcoded `PLAYWRIGHT_VERSION="v1.57.0"` while `@playwright/test` is pinned to `1.59.1` in the lockfile. Playwright aborts at `browserType.launch` when the browser image and client versions disagree, so `pnpm test:e2e:update:docker` and `pnpm e2e:docker` both failed with its own "Please update docker image as well" error. Deriving the tag from `@playwright/test/package.json` at run-time prevents this from drifting again.

## Details

### Key changes

- Replace the hardcoded `PLAYWRIGHT_VERSION` string in both [e2e/scripts/run-e2e-docker.sh](e2e/scripts/run-e2e-docker.sh) and [e2e/scripts/update-snapshots.sh](e2e/scripts/update-snapshots.sh) with `v$(cd "$E2E_DIR" && node -p "require('@playwright/test/package.json').version")` so the image tag follows the npm pin
- In [e2e/scripts/update-snapshots.sh](e2e/scripts/update-snapshots.sh), accept passthrough args (default `--project=chromium`) so callers can regenerate snapshots for other Playwright projects without editing the script, e.g. `pnpm test:e2e:update:docker -- --project=<other-project>`
- Add anonymous volumes for `packages/vue/node_modules` and `examples/vue/node_modules` in [e2e/scripts/update-snapshots.sh](e2e/scripts/update-snapshots.sh) to keep host `node_modules` isolated once those workspaces land (a forthcoming Vue package PR will add matching mounts to `run-e2e-docker.sh`)

### Testing

- `bash -n` clean on both scripts
- Running `pnpm test:e2e:update:docker` locally with Docker pulled `mcr.microsoft.com/playwright:v1.59.1` correctly and all 33 chromium tests passed in ~36s with no snapshot deltas
- No changes under `packages/`, `examples/`, `e2e/tests/`, or `.github/workflows/` — this is infra only