### PR TITLE
chore(e2e): fix pnpm arg forwarding in docker helper scripts

### DIFF
--- a/e2e/scripts/run-e2e-docker.sh
+++ b/e2e/scripts/run-e2e-docker.sh
@@ -14,8 +14,16 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Default to chromium project (matches CI)
+# pnpm forwards the caller's `--` separator token through every script layer,
+# so if present it arrives as a literal first arg here. Drop it before reading
+# positionals — otherwise PROJECT would be set to "--".
+if [ "${1:-}" = "--" ]; then shift; fi
+
+# Default to chromium project (matches CI); callers may follow the project
+# name with additional playwright flags, e.g. `./run-e2e-docker.sh chromium --headed`
 PROJECT="${1:-chromium}"
+if [ $# -gt 0 ]; then shift; fi
+EXTRA_ARGS=("$@")
 
 echo -e "${YELLOW}Running E2E tests in Docker (Linux environment)...${NC}"
 echo ""
@@ -33,6 +41,7 @@ IMAGE="mcr.microsoft.com/playwright:${PLAYWRIGHT_VERSION}"
 
 echo "Using Playwright image: $IMAGE"
 echo "Project: $PROJECT"
+echo "Extra args: ${EXTRA_ARGS[*]}"
 echo ""
 
 # Run tests in Docker with isolated node_modules
@@ -56,7 +65,7 @@ docker run --rm \
     pnpm install --frozen-lockfile && \
     pnpm build && \
     cd e2e && \
-    pnpm e2e --project=$PROJECT
+    pnpm exec playwright test --grep-invert \"connect wallet button\" --project=$PROJECT ${EXTRA_ARGS[*]}
   "
 
 EXIT_CODE=$?

--- a/e2e/scripts/run-e2e-docker.sh
+++ b/e2e/scripts/run-e2e-docker.sh
@@ -39,7 +39,12 @@ fi
 PLAYWRIGHT_VERSION="v$(cd "$E2E_DIR" && node -p "require('@playwright/test/package.json').version")"
 IMAGE="mcr.microsoft.com/playwright:${PLAYWRIGHT_VERSION}"
 
+# Pin pnpm inside the container to the root packageManager version so Renovate's
+# pnpm bumps to the root manifest don't silently desync from this script
+PNPM_VERSION="$(node -p "require('$ROOT_DIR/package.json').packageManager.split('@')[1]")"
+
 echo "Using Playwright image: $IMAGE"
+echo "Using pnpm: $PNPM_VERSION"
 echo "Project: $PROJECT"
 echo "Extra args: ${EXTRA_ARGS[*]}"
 echo ""
@@ -61,7 +66,7 @@ docker run --rm \
   "$IMAGE" \
   /bin/bash -c "
     cd /work && \
-    npm install -g pnpm@10.12.4 && \
+    npm install -g pnpm@$PNPM_VERSION && \
     pnpm install --frozen-lockfile && \
     pnpm build && \
     cd e2e && \

--- a/e2e/scripts/update-snapshots.sh
+++ b/e2e/scripts/update-snapshots.sh
@@ -42,7 +42,12 @@ fi
 PLAYWRIGHT_VERSION="v$(cd "$E2E_DIR" && node -p "require('@playwright/test/package.json').version")"
 IMAGE="mcr.microsoft.com/playwright:${PLAYWRIGHT_VERSION}"
 
+# Pin pnpm inside the container to the root packageManager version so Renovate's
+# pnpm bumps to the root manifest don't silently desync from this script
+PNPM_VERSION="$(node -p "require('$ROOT_DIR/package.json').packageManager.split('@')[1]")"
+
 echo "Using Playwright image: $IMAGE"
+echo "Using pnpm: $PNPM_VERSION"
 echo "Mounting: $ROOT_DIR -> /work"
 echo "Project args: ${PROJECT_ARGS[*]}"
 echo ""
@@ -67,7 +72,7 @@ docker run --rm \
   "$IMAGE" \
   /bin/bash -c "
     cd /work && \
-    npm install -g pnpm@10.12.4 && \
+    npm install -g pnpm@$PNPM_VERSION && \
     pnpm install --frozen-lockfile && \
     pnpm build && \
     cd e2e && \

--- a/e2e/scripts/update-snapshots.sh
+++ b/e2e/scripts/update-snapshots.sh
@@ -17,6 +17,13 @@ NC='\033[0m' # No Color
 # Default to chromium project (matches CI); callers can override via args,
 # e.g. `pnpm test:e2e:update:docker -- --project=vue-chromium`
 PROJECT_ARGS=("$@")
+# pnpm forwards the caller's `--` separator token through every script layer,
+# so if present it arrives as a literal arg here. Drop it so it doesn't land
+# between `playwright test` and the forwarded flags — playwright would treat
+# everything after `--` as positional test-file regexes and match nothing.
+if [ "${PROJECT_ARGS[0]:-}" = "--" ]; then
+  PROJECT_ARGS=("${PROJECT_ARGS[@]:1}")
+fi
 if [ ${#PROJECT_ARGS[@]} -eq 0 ]; then
   PROJECT_ARGS=(--project=chromium)
 fi
@@ -64,7 +71,7 @@ docker run --rm \
     pnpm install --frozen-lockfile && \
     pnpm build && \
     cd e2e && \
-    pnpm e2e:update ${PROJECT_ARGS[*]}
+    pnpm exec playwright test --update-snapshots ${PROJECT_ARGS[*]}
   "
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes a bug in the Playwright docker helper scripts where `pnpm test:e2e:update:docker -- --project=<name>` failed with `Error: No tests found.` pnpm 10 forwards the caller's `--` separator token verbatim through every script layer, so the project flag landed on the wrong side of a `--` inside the container and Playwright parsed it as a positional test-file regex. Also derives the in-container pnpm version from the root `packageManager` field so Renovate's bumps can't silently desync the pin.

Title prefixed `chore` so the squash-merge doesn't trigger the semantic-release / npm-publish pipeline — these are dev-only helper scripts, no library behavior changes.

## Details

**Key changes**

- Invoke the playwright binary directly via `pnpm exec` instead of chaining through the `pnpm e2e:update` / `pnpm e2e` scripts, eliminating one script-resolution layer.
- Strip a leading `--` token from forwarded args in both scripts so it can't land between the binary and its flags.
- `run-e2e-docker.sh` now also forwards trailing passthrough flags (e.g. `--headed`, `--grep`) past the project name, while preserving the `--grep-invert "connect wallet button"` filter that `pnpm e2e` applies by default.
- Replace hardcoded `pnpm@10.12.4` in both scripts with a value derived from the root `package.json` `packageManager` field at runtime, mirroring the Playwright-image-tag derivation from #57.

**Verification**

Verified first without Docker by running each resolved inner command directly against the local Playwright install with `--list` (safe — no snapshot writes, no dev-server startup). All documented invocations resolve correctly:

| Invocation | Resolved command | Result |
|---|---|---|
| `pnpm test:e2e:update:docker` | `pnpm exec playwright test --update-snapshots --project=chromium` | 33 tests |
| `pnpm test:e2e:update:docker -- --project=firefox` | `pnpm exec playwright test --update-snapshots --project=firefox` | 33 tests |
| `pnpm test:e2e:update:docker -- --project=chromium --project=firefox` | `...--project=chromium --project=firefox` | 66 tests |
| `pnpm e2e:docker` | `pnpm exec playwright test --grep-invert "connect wallet button" --project=chromium` | 29 tests |
| `pnpm e2e:docker firefox --forbid-only` | `...--project=firefox --forbid-only` | 29 tests |

The 29-vs-33 delta confirms the default grep-invert filter is preserved (4 button-visual tests excluded).

Then exercised end-to-end in Docker:

## Test plan

- [x] `pnpm test:e2e:update:docker -- --project=chromium` — 33 tests ran (was "No tests found" before), all 33 passed, `git status` remained clean (snapshots idempotent)
- [x] `pnpm test:e2e:update:docker` (no args) — defaulted to `Project args: --project=chromium`, 33 passed, snapshots idempotent
- [x] Within `e2e/`, `pnpm e2e:docker` — 29 tests ran and passed, confirming the `--grep-invert "connect wallet button"` filter is preserved by the new `pnpm exec` invocation
- [x] In-container `Using pnpm: 10.33.0` log line matches the root `packageManager` pin (`pnpm@10.33.0`)