### PR TITLE
ci: scope React release + add manual Vue publish workflow

### DIFF
--- a/.github/workflows/release-vue.yml
+++ b/.github/workflows/release-vue.yml
@@ -1,0 +1,79 @@
+name: Release Vue (manual)
+
+# Manual publish for @txnlab/use-wallet-ui-vue.
+#
+# The Vue package is published out-of-band from semantic-release (which only
+# handles the React package). Bump packages/vue/package.json "version" in a
+# commit/PR first, then trigger this workflow from the Actions tab.
+#
+# Auth: runs with id-token: write so npm provenance is generated. The first
+# publish of the (new) package name uses the NPM_TOKEN secret; once the package
+# exists and trusted publishing is configured on npmjs.com, NODE_AUTH_TOKEN
+# resolves to empty and the publish authenticates tokenlessly via OIDC.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (pack only, do not publish)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Update npm to latest
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm --filter @txnlab/use-wallet-ui-vue lint
+
+      - name: Type Check
+        run: pnpm --filter @txnlab/use-wallet-ui-vue typecheck
+
+      - name: Test
+        run: pnpm --filter @txnlab/use-wallet-ui-vue test
+
+      - name: Build
+        run: pnpm --filter @txnlab/use-wallet-ui-vue build
+
+      - name: Verify dependency signatures
+        run: npm audit signatures
+
+      - name: Publish (dry run)
+        if: ${{ inputs.dry_run }}
+        working-directory: packages/vue
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish
+        if: ${{ !inputs.dry_run }}
+        working-directory: packages/vue
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,27 @@ jobs:
       - name: Verify dependency signatures
         run: npm audit signatures
 
+      # The React package is released by semantic-release (pkgRoot: packages/react),
+      # but the commit analyzer is not path-scoped. Without this guard, a push that
+      # only touched the Vue package (or examples) would still cut a React release.
+      # Skip the release step unless commits since the last v* tag touched
+      # release-relevant React paths. NOTE: a commit touching both packages still
+      # releases React with the Vue notes included — the clean per-package fix lands
+      # with the future monorepo release migration.
+      - name: Check for React-relevant changes
+        id: react_changes
+        run: |
+          LAST_TAG=$(git describe --tags --match 'v[0-9]*' --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ] || git diff --name-only "$LAST_TAG"..HEAD -- \
+               packages/react pnpm-lock.yaml .releaserc.js .github/workflows/release.yml | grep -q .; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No React-relevant changes since $LAST_TAG — skipping release."
+          fi
+
       - name: Release
+        if: steps.react_changes.outputs.run == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GIT_AUTHOR_NAME: TxnLab Release Bot[bot]


### PR DESCRIPTION
## Summary

Prep for publishing `@txnlab/use-wallet-ui-vue` (#55) with the bare-minimum change to the release pipeline — leaving React's automation intact. Adds a guard so Vue changes don't trigger spurious React releases, plus a manual `workflow_dispatch` job to publish the Vue package. The full per-package semantic-release migration is intentionally deferred.

**Merge this before #55** so the guard is on `main` when the Vue PR's merge commit triggers `release.yml`.

## Details

**Scope React's release (`release.yml`)**
`semantic-release` is hardwired to `pkgRoot: packages/react`, but its commit analyzer is not path-scoped — once the Vue package lands, a push touching only `packages/vue` (or examples) would still cut a React release. This adds a CI-level guard that skips the `Release` step unless commits since the last `v*` tag touched release-relevant React paths (`packages/react`, `pnpm-lock.yaml`, `.releaserc.js`, the workflow itself).

- Keeps `.releaserc.js` and the existing `v${version}` tag history untouched.
- Interim trade-off: a commit touching *both* packages still releases React with the Vue notes included — the clean per-package fix comes with the future monorepo release migration.

**Manual Vue publish (`release-vue.yml`, new)**
`workflow_dispatch` job that builds and publishes `@txnlab/use-wallet-ui-vue` from `packages/vue` with OIDC provenance, with a `dry_run` input. Uses `secrets.NPM_TOKEN` for the first publish of the new package name; once the package exists and trusted publishing is configured, `NODE_AUTH_TOKEN` resolves empty and it authenticates tokenlessly via OIDC.