### PR TITLE
ci: gate React release on releasable React commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,23 +60,30 @@ jobs:
       - name: Verify dependency signatures
         run: npm audit signatures
 
-      # The React package is released by semantic-release (pkgRoot: packages/react),
-      # but the commit analyzer is not path-scoped. Without this guard, a push that
-      # only touched the Vue package (or examples) would still cut a React release.
-      # Skip the release step unless commits since the last v* tag touched
-      # release-relevant React paths. NOTE: a commit touching both packages still
-      # releases React with the Vue notes included — the clean per-package fix lands
-      # with the future monorepo release migration.
-      - name: Check for React-relevant changes
+      # semantic-release is hardwired to packages/react (pkgRoot) but its commit
+      # analyzer is NOT path-scoped, so it would otherwise attribute a Vue feat/fix
+      # commit to a React release. Guard the release step: run only if a releasing
+      # commit (feat/fix/BREAKING) since the last v* tag actually touched
+      # packages/react. We scope by pathspec (so a Vue-only feat is excluded) AND by
+      # commit type (so accumulated chore(deps) bumps alone don't trigger a release),
+      # which together mirror what semantic-release would legitimately release.
+      # NOTE: a single commit touching BOTH packages still releases React with the
+      # Vue notes — the clean per-package fix lands with the future monorepo migration.
+      - name: Check for releasable React changes
         id: react_changes
         run: |
           LAST_TAG=$(git describe --tags --match 'v[0-9]*' --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ] || git diff --name-only "$LAST_TAG"..HEAD -- \
-               packages/react pnpm-lock.yaml .releaserc.js .github/workflows/release.yml | grep -q .; then
+          RANGE="${LAST_TAG:+$LAST_TAG..HEAD}"
+          # Subjects and bodies of commits since the last tag that touched packages/react
+          SUBJECTS=$(git log ${RANGE:-HEAD} --no-merges --format='%s' -- packages/react)
+          BODIES=$(git log ${RANGE:-HEAD} --no-merges --format='%B' -- packages/react)
+          if [ -z "$LAST_TAG" ] \
+             || printf '%s\n' "$SUBJECTS" | grep -qE '^(feat|fix)(\(.+\))?!?:' \
+             || printf '%s\n' "$BODIES" | grep -q 'BREAKING CHANGE'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "No React-relevant changes since $LAST_TAG — skipping release."
+            echo "No releasable React (feat/fix/BREAKING) commit since $LAST_TAG — skipping release."
           fi
 
       - name: Release

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,9 +1,7 @@
 # [1.2.0](https://github.com/TxnLab/use-wallet-ui/compare/v1.1.0...v1.2.0) (2026-06-08)
 
 
-### Features
-
-* add Vue library ([#55](https://github.com/TxnLab/use-wallet-ui/issues/55)) ([4d10cdd](https://github.com/TxnLab/use-wallet-ui/commit/4d10cdd38faec2ea03f6877ad50fcd620582ed19))
+This release contains only dependency updates accumulated since 1.1.0 — there are no functional changes to the React package. The minor version bump was an artifact of the monorepo release configuration when the Vue package ([#55](https://github.com/TxnLab/use-wallet-ui/issues/55)) was added, since corrected in [#70](https://github.com/TxnLab/use-wallet-ui/pull/70).
 
 # [1.1.0](https://github.com/TxnLab/use-wallet-ui/compare/v1.0.0...v1.1.0) (2026-03-04)
 


### PR DESCRIPTION
## Summary

The release guard from #69 didn't actually stop the spurious React release — merging #55 published `@txnlab/use-wallet-ui-react@1.2.0` ([run](https://github.com/TxnLab/use-wallet-ui/actions/runs/27160842423)). This corrects the guard, and rewords the misleading `1.2.0` changelog entry (it bundled only dependency updates — no React changes).

**Merging won't trigger a release:** the guard evaluates `run=false` (nothing since `v1.2.0` touched `packages/react`) and the squash uses a non-releasing `ci:` type.

## Details

The old guard watched the shared `pnpm-lock.yaml` (any Vue change regenerates it) and only checked whether *files* changed — so accumulated `chore(deps)` bumps plus the `feat: add Vue library` commit still cut a release.

The fix gates on whether a **feat/fix/BREAKING commit since the last `v*` tag actually touched `packages/react`**: `git log <range> -- packages/react` excludes Vue-only commits, and the type check ignores chore-only ranges. Verified: the `#55` range → skip; a real React fix range → run.

Still a band-aid on the single-package pipeline; the clean per-package fix belongs to the deferred monorepo release migration.