### PR TITLE
fix(css): render library SVG icons as block in standalone CSS

### DIFF
--- a/packages/react/src/input.css
+++ b/packages/react/src/input.css
@@ -70,6 +70,20 @@
   height: auto;
 }
 
+/*
+  SVG resets for library elements.
+  Mirrors Tailwind preflight (svg { display: block }), which the Tailwind flavor
+  inherits from the consumer's preflight but the standalone CSS otherwise omits.
+  Without this, library icons default to display: inline and the baseline gap
+  distorts tightly-wrapped controls (e.g. the rounded "Close dialog" button).
+*/
+[data-wallet-ui] [role="dialog"] svg,
+[data-wallet-ui] [role="menu"] svg,
+[data-wallet-ui] [role="listbox"] svg {
+  display: block;
+  vertical-align: middle;
+}
+
 /* Theme - CSS custom properties */
 
 /* Light mode (default) */


### PR DESCRIPTION
## Summary

In the standalone (non-Tailwind) CSS flavor, the "Close dialog" (×) button rendered as a squished oval instead of a circle. The fix adds a scoped `svg` reset so library icons render `display: block`, matching the Tailwind flavor.

Only affects `packages/react`'s standalone `dist/style.css`; the Tailwind flavor was never affected. On merge this releases `react@1.2.1` (and carries out the already-merged IPFS fix from #62, which missed its release due to a malformed commit title).

| Before (`main`) | After |
| --- | --- |
| SVG defaults to `display: inline` → baseline gap distorts the `rounded-full` button | `display: block` → clean circle |

## Details

**Root cause.** The standalone CSS ships a minimal scoped reset instead of Tailwind's full preflight (to avoid clobbering consumer elements). It mirrored preflight for `<img>` but omitted `<svg>`, so library icons fell back to the UA default `display: inline`. The inline baseline gap stretched tightly-wrapped controls like the close button. The Tailwind flavor was unaffected because the consumer's own preflight already sets `svg { display: block }` — which is why it only showed up in the non-Tailwind flavor. (`h-5 w-5` resolved correctly all along — `--spacing` is defined; the missing piece was `display`, not size.)

**Fix.** Add a scoped `svg` reset to `input.css` mirroring preflight and the existing `img` block:

```css
[data-wallet-ui] [role="dialog"] svg,
[data-wallet-ui] [role="menu"] svg,
[data-wallet-ui] [role="listbox"] svg {
  display: block;
  vertical-align: middle;
}
```

This fixes every library icon in the standalone flavor, stays scoped to library components (no consumer impact), and matches the existing reset architecture. `dist/style.css` regenerates at build time.

## Verification

- Reproduced the oval on `main`; confirmed the fix restores the circle in the `react-css-only` example.
- `pnpm build` (+ `publint --strict`), lint, typecheck, and unit tests all pass.
- Standalone-flavor e2e (`customization` project, computed-style assertions) — all 9 pass.
- No visual snapshots affected: the snapshot suite runs only against the Tailwind examples, which this change doesn't touch.

## Follow-up (not in this PR)

The Vue package's standalone CSS uses `@import 'tailwindcss';` (full preflight) and the post-processor only scopes class selectors, so Vue's `dist/style.css` ships Tailwind's **entire preflight globally unscoped** (`*`, `h1`–`h6`, `button`, …). That clobbers consumer elements for CSS-only Vue consumers — a separate fix and its own manual Vue release.